### PR TITLE
navigate to character

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Smarter, horizontal navigation in vim.
 
-[![asciicast](https://asciinema.org/a/8dtiq6m4fzoh7fgz872g5oi0s.png)](https://asciinema.org/a/8dtiq6m4fzoh7fgz872g5oi0s)
+
+[![asciicast](https://asciinema.org/a/7ewafmt0dx3ruwjphpwew1c8g.png)](https://asciinema.org/a/7ewafmt0dx3ruwjphpwew1c8g?autoplay=1)
 
 `vim-nav` is a simple plugin that hijacks `b` and `e` for smarter navigation between characters. **vim-nav** allows you to navigate through snake case, camel case and normal word breaks. Break characters are also configurable for custom navigation.
 

--- a/lib/nav.py
+++ b/lib/nav.py
@@ -77,7 +77,7 @@ def move(direction, count=1):
         # if we hit a white space on the first element, then we want to keep
         # going to find the next non-whitespace element
         if re.match(r'\s', char) or re.match(r'\n', char):
-            if moved > 0:
+            if moved > 1:
                 col -= direction
                 # if col is less than zero, it means we are moving forward and
                 # the last position was the last character of the previous
@@ -94,7 +94,10 @@ def move(direction, count=1):
                     col = 0
                 break
             else:
+                moved += 1
+                col += direction
                 is_empty = True
+                continue
 
         # if we've move more than one character, are going backwards and are on
         # the first element in a list then we can break 
@@ -106,7 +109,9 @@ def move(direction, count=1):
             break
 
         # the current character has a different case than the start char
-        if (char.lower() == char) != (start_char == start_char.lower()):
+        if start_char == start_char.lower() and char == char.upper():
+            break
+        if start_char == start_char.upper() and char == char.upper() and moved > 0:
             break
             
         # if the current character is one of our delimiter characters break,
@@ -129,6 +134,7 @@ def move(direction, count=1):
 
     # move to the correct character
     vim.current.window.cursor = (row+1, col)
+    return move(direction, count-1)
 
 
 def forwards(count=1):

--- a/plugin/vim-nav.vim
+++ b/plugin/vim-nav.vim
@@ -23,9 +23,8 @@ import nav
 EOF
 
 " map b in normal mode to nav.backwards()
-nmap b :python nav.backwards()<CR>
-"nmap b :normal n.:python nav.backwards()<CR>
+"nmap b :python nav.backwards()<CR>
+"nmap b @dd
 
-" map e in normal mode to nav.forwards()
-nmap e :python nav.forwards()<CR>
-"nmap e :normal n.:python nav.backwards()<CR>
+:nnoremap b :<C-U>exe ":python nav.backwards(count=".v:count1.")"<CR>
+:nnoremap e :<C-U>exe ":python nav.forwards(count=".v:count1.")"<CR>


### PR DESCRIPTION
It'd be nice to be able to navigate to the next instance of a character.

_eg:_

`:normal b a` - go to the last instance of "a"
`:normal 2b a` - go to the second to last instance of "a"

`:normal 2f *` - go two instances of "f" forward
